### PR TITLE
Fix filename errors in python README

### DIFF
--- a/python/readme.md
+++ b/python/readme.md
@@ -249,7 +249,7 @@ Total Credit:    $ 1500.00
     into a list.
 
 3.  Implement the `generateReport` function: it should take a list
-    of children, iterate over it and output output a table similar to
+    of children, iterate over it and output a table similar to
     the one above.  Your function should then return the total credit.
     Note: to access a member variable, use the dot operator; example:
     `tom.age` (Python does not have private member variables)

--- a/python/readme.md
+++ b/python/readme.md
@@ -244,7 +244,7 @@ Total Credit:    $ 1500.00
 1.  Open the `child.py` and `child_credit.py` script files
 
 2.  A `Child` class has already been defined and included in the
-    `child_credit.php` script. Observe how the `Child` class is used.
+    `child_credit.py` script. Observe how the `Child` class is used.
     Several instances of children have been created and placed
     into a list.
 
@@ -255,7 +255,7 @@ Total Credit:    $ 1500.00
     `tom.age` (Python does not have private member variables)
 
 4.  Test your implementation by the provided unit test suite:
-    `python test_natural.py`  
+    `python test_child_credit.py`  
 
 ### 4. Testing, Submitting & Grading
 


### PR DESCRIPTION
The child credit file was mislabeled as a PHP file. In addition, the testing suite for the child credit program was mislabeled as `test_natural.py`. There was also a grammar issue with the sentence "Implement the `generateReport` function: it should take a list of children, iterate over it and _output output_ a table similar to..."